### PR TITLE
Do pre-installed check in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
 
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.
-  - "powershell ./appveyor/install.ps1"
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
 
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart


### PR DESCRIPTION
Rather than hide the pre-installed check in install.ps1,
show that it is not needed in the main build script.