### PR TITLE
Add Python 2.6.5 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ install:
 
   # pip on Python 2.6.5 fails unless ndg-httpsclient is installed.
   # ndg-httpsclient will also install PyOpenSSL, pyasn1, and others
-  - ps: if ([version]$env:PYTHON_VERSION -lt [version]"2.6.6") { & pip.exe --trusted-host pypi.python.org install ndg-httpsclient 2>$null }
+  - ps: if ([version](($env:PYTHON_VERSION).replace('.x', '')) -lt [version]"2.6.6") { & pip.exe --trusted-host pypi.python.org install ndg-httpsclient 2>$null }
 
   # Check that we have the expected version and architecture for Python
   - "python --version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,10 +62,6 @@ install:
   # the parent CMD process).
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  # pip on Python 2.6.5 fails unless ndg-httpsclient is installed.
-  # ndg-httpsclient will also install PyOpenSSL, pyasn1, and others
-  - ps: if ([version](($env:PYTHON_VERSION).replace('.x', '')) -lt [version]"2.6.6") { & pip.exe --trusted-host pypi.python.org install ndg-httpsclient 2>$null }
-
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,16 @@ environment:
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "64"
 
-    # Also test a Python version not pre-installed
-    # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
+    # Python 2.6.6 is the only Python 2.6 version that can be installed
+    # without installing extra dependencies. See:
+    # https://github.com/ogrisel/python-appveyor-demo/issues/10
 
     - PYTHON: "C:\\Python266"
       PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python265"
+      PYTHON_VERSION: "2.6.5"
       PYTHON_ARCH: "32"
 
 install:
@@ -56,6 +61,10 @@ install:
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # pip on Python 2.6.5 fails unless ndg-httpsclient is installed.
+  # ndg-httpsclient will also install PyOpenSSL, pyasn1, and others
+  - ps: if ([version]$env:PYTHON_VERSION -lt [version]"2.6.6") { & pip.exe --trusted-host pypi.python.org install ndg-httpsclient 2>$null }
 
   # Check that we have the expected version and architecture for Python
   - "python --version"

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -86,8 +86,13 @@ function InstallPip ($python_home) {
         Write-Host "Installing pip..."
         $webclient = New-Object System.Net.WebClient
         $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
-        Write-Host "Executing:" $python_path $GET_PIP_PATH
-        Start-Process -FilePath "$python_path" -ArgumentList "$GET_PIP_PATH" -Wait -Passthru
+        if ([version]$env:PYTHON_VERSION -gt [version]"2.6.5") {
+            RunCommand "$python_path" "$GET_PIP_PATH"
+        } else {
+            # Workaround for Python 2.6.5 and lower
+            # https://github.com/ogrisel/python-appveyor-demo/issues/10
+            RunCommand "$python_path" "$GET_PIP_PATH --trusted-host pypi.python.org"
+        }
     } else {
         Write-Host "pip already installed."
     }

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -92,6 +92,8 @@ function InstallPip ($python_home) {
             # Workaround for Python 2.6.5 and lower
             # https://github.com/ogrisel/python-appveyor-demo/issues/10
             RunCommand "$python_path" "$GET_PIP_PATH --trusted-host pypi.python.org"
+            Write-Host "Installing ndg-httpsclient to workaround pip bug on Python 2.6.5 and lower."
+            & pip.exe --trusted-host pypi.python.org install ndg-httpsclient 2>$null
         }
     } else {
         Write-Host "pip already installed."


### PR DESCRIPTION
On Python 2.6.5, use "--trusted-host pypi.python.org" to
install pip and ndg-httpsclient.

Fixes #10.