### PR TITLE
Pre 3.3 major and minor release numbering scheme

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,20 @@ environment:
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "64"
 
-    # Also test a Python version not pre-installed
+    # Python versions not pre-installed
+
+    # Python 2.6.6 is the latest Python 2.6 with a Windows installer
     # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
 
     - PYTHON: "C:\\Python266"
       PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
+    # Major and minor releases (i.e x.0.0 and x.y.0) prior to 3.3.0 use
+    # a different naming scheme.
+
+    - PYTHON: "C:\\Python270"
+      PYTHON_VERSION: "2.7.0"
       PYTHON_ARCH: "32"
 
 install:

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -9,6 +9,10 @@ $GET_PIP_PATH = "C:\get-pip.py"
 
 
 function DownloadPython ($python_version, $platform_suffix) {
+    $version_obj = [version]$python_version
+    if ($version_obj -lt [version]'3.3.0' -and $version_obj.Build -eq 0) {
+        $python_version = "$($version_obj.Major).$($version_obj.Minor)"
+    }
     $webclient = New-Object System.Net.WebClient
     $filename = "python-" + $python_version + $platform_suffix + ".msi"
     $url = $BASE_URL + $python_version + "/" + $filename


### PR DESCRIPTION
Detect major and minor releases before 3.3 to use
'x.y' instead of 'x.y.0' when downloading Python.

Fixes issue #9