### PR TITLE
Switch HTTP links to HTTPS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -113,4 +113,4 @@ Affirmer's express Statement of Purpose.
   CC0 or use of the Work.
 
 For more information, please see
-<http://creativecommons.org/publicdomain/zero/1.0/>
+<https://creativecommons.org/publicdomain/zero/1.0/>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ python-appveyor-demo
 ====================
 
 Demo project for building Windows [Python wheels](http://pythonwheels.com/)
-using http://appveyor.com. It supports both Python 2 and 3 on 32 and 64 bit
+using https://appveyor.com. It supports both Python 2 and 3 on 32 and 64 bit
 architectures.
 
 AppVeyor is a continuous integration platform similar to travis-ci.org but for
@@ -24,7 +24,7 @@ The `appveyor.yml` file in this repo configures a Windows build environment for
 both for 32 bit and 64 bit Python compiled extensions. This demo project is
 configured to trigger build jobs at:
 
-  http://ci.appveyor.com/project/ogrisel/python-appveyor-demo
+  https://ci.appveyor.com/project/ogrisel/python-appveyor-demo
 
 In particular:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
 
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
-    # See: http://www.appveyor.com/docs/installed-software#python
+    # See: https://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x" # currently 2.7.9
@@ -93,7 +93,7 @@ install:
   - ECHO "Installed SDKs:"
   - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
 
-  # Install Python (from the official .msi of http://python.org) and pip when
+  # Install Python (from the official .msi of https://python.org) and pip when
   # not already installed.
   - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
 

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,8 +1,8 @@
 # Sample script to install Python and pip under Windows
 # Authors: Olivier Grisel, Jonathan Helmus, Kyle Kastner, and Alex Willmer
-# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+# License: CC0 1.0 Universal: https://creativecommons.org/publicdomain/zero/1.0/
 
-$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+$MINICONDA_URL = "https://repo.continuum.io/miniconda/"
 $BASE_URL = "https://www.python.org/ftp/python/"
 $GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 $GET_PIP_PATH = "C:\get-pip.py"

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -17,7 +17,7 @@
 :: http://stackoverflow.com/a/13751649/163740
 ::
 :: Author: Olivier Grisel
-:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+:: License: CC0 1.0 Universal: https://creativecommons.org/publicdomain/zero/1.0/
 ::
 :: Notes about batch files for Python people:
 ::


### PR DESCRIPTION
Aside from stackoverflow.com and pythonwheels.com, all referenced sites
support HTTPS. So, might as well use it.
