### PR TITLE
appveyor.yml unnecessarily complicated

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,79 +3,79 @@ environment:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    CMD_IN_ENV: cmd /E:ON /V:ON /C .\appveyor\run_with_env.cmd
 
   matrix:
 
     # Python 2.7.10 is the latest version and is not pre-installed.
 
-    - PYTHON: "C:\\Python27.10"
-      PYTHON_VERSION: "2.7.10"
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python27.10
+      PYTHON_VERSION: 2.7.10
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python27.10-x64"
-      PYTHON_VERSION: "2.7.10"
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python27.10-x64
+      PYTHON_VERSION: 2.7.10
+      PYTHON_ARCH: '64'
 
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python27
+      PYTHON_VERSION: 2.7.x # currently 2.7.9
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python27-x64
+      PYTHON_VERSION: 2.7.x # currently 2.7.9
+      PYTHON_ARCH: '64'
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python33
+      PYTHON_VERSION: 3.3.x # currently 3.3.5
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python33-x64
+      PYTHON_VERSION: 3.3.x # currently 3.3.5
+      PYTHON_ARCH: '64'
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python34
+      PYTHON_VERSION: 3.4.x # currently 3.4.3
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python34-x64
+      PYTHON_VERSION: 3.4.x # currently 3.4.3
+      PYTHON_ARCH: '64'
 
     # Python versions not pre-installed
 
     # Python 2.6.6 is the latest Python 2.6 with a Windows installer
     # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
 
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python266
+      PYTHON_VERSION: 2.6.6
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python266-x64"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python266-x64
+      PYTHON_VERSION: 2.6.6
+      PYTHON_ARCH: '64'
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.0"
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python35
+      PYTHON_VERSION: 3.5.0
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.0"
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python35-x64
+      PYTHON_VERSION: 3.5.0
+      PYTHON_ARCH: '64'
 
     # Major and minor releases (i.e x.0.0 and x.y.0) prior to 3.3.0 use
     # a different naming scheme.
 
-    - PYTHON: "C:\\Python270"
-      PYTHON_VERSION: "2.7.0"
-      PYTHON_ARCH: "32"
+    - PYTHON: C:\Python270
+      PYTHON_VERSION: 2.7.0
+      PYTHON_ARCH: '32'
 
-    - PYTHON: "C:\\Python270-x64"
-      PYTHON_VERSION: "2.7.0"
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python270-x64
+      PYTHON_VERSION: 2.7.0
+      PYTHON_ARCH: '64'
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -88,10 +88,10 @@ install:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
   - ECHO "Filesystem root:"
-  - ps: "ls \"C:/\""
+  - ps: ls "C:/"
 
   - ECHO "Installed SDKs:"
-  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+  - ps: ls "C:/Program Files/Microsoft SDKs/Windows"
 
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.
@@ -100,36 +100,36 @@ install:
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
   # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - python --version
+  - python -c "import struct; print(struct.calcsize('P') * 8)"
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - pip install --disable-pip-version-check --user --upgrade pip
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+  - '%CMD_IN_ENV% pip install -r dev-requirements.txt'  # % cannot occur at the start of an unquoted scalar
 
 build_script:
   # Build the compiled extension
-  - "%CMD_IN_ENV% python setup.py build"
+  - '%CMD_IN_ENV% python setup.py build'
 
 test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% python setup.py nosetests"
+  - '%CMD_IN_ENV% python setup.py nosetests'
 
 after_test:
   # If tests are successful, create binary packages for the project.
-  - "%CMD_IN_ENV% python setup.py bdist_wheel"
-  - "%CMD_IN_ENV% python setup.py bdist_wininst"
-  - "%CMD_IN_ENV% python setup.py bdist_msi"
-  - ps: "ls dist"
+  - '%CMD_IN_ENV% python setup.py bdist_wheel'
+  - '%CMD_IN_ENV% python setup.py bdist_wininst'
+  - '%CMD_IN_ENV% python setup.py bdist_msi'
+  - ps: ls dist
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.


### PR DESCRIPTION
Most string scalars (but not all) are double quoted scalars, making the file less readable.

YAML allows any string through backslashes within double quotes, but also requires backslashes and double quotes to be escaped. The example can be made much more readable
by using non-quoted scalar strings, or single quoted ones (in case the scalar starts with a `%` or can be interpreted as an integer.

This was originally proposed as change for the user guide (https://github.com/pypa/python-packaging-user-guide/issues/221#issuecomment-249680859)

(Depending on how the program that loads the file handles the value for `PYTHON_ARCH`, the quotes around those values could be removed  as well, assuming the program transparently converts from integer to string internally if necessary. )