### PR TITLE
appveyor.yml Upload test results

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,14 +121,12 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build"
 
 test_script:
-  # Run the project tests and upload results
+  # Run the project tests and store results in .xml log
   - ps: |
+      # this produces nosetests.xml which is uploaded on_finish
       &$env:PYTHON\python setup.py nosetests --with-xunit
       if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-      # upload results to AppVeyor
-      $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))
-
+      
 after_test:
   # If tests are successful, create binary packages for the project.
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
@@ -143,3 +141,10 @@ artifacts:
 #on_success:
 #  - TODO: upload the content of dist/*.whl to a public wheelhouse
 #
+
+on_finish:
+  # Upload test results to AppVeyor
+  - ps: |
+      # this uploads nosetests.xml produced in test_script step
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,8 +121,13 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build"
 
 test_script:
-  # Run the project tests
-  - "%CMD_IN_ENV% python setup.py nosetests"
+  # Run the project tests and upload results
+  - ps: |
+      &$env:CMD_IN_ENV python setup.py nosetests --with-xunit
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+      # upload results to AppVeyor
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\nosetests.xml))
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -123,7 +123,7 @@ build_script:
 test_script:
   # Run the project tests and upload results
   - ps: |
-      &$env:CMD_IN_ENV python setup.py nosetests --with-xunit
+      &$env:PYTHON\python setup.py nosetests --with-xunit
       if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
       # upload results to AppVeyor
       $wc = New-Object 'System.Net.WebClient'


### PR DESCRIPTION
See https://www.appveyor.com/docs/running-tests/#uploading-xml-test-results
and https://www.appveyor.com/docs/build-configuration/#script-blocks-in-build-configuration

AppVeyor /xunit/ endpoint uses xUnit.net test format, so `nosetest` report should
be uploaded to /junit/
