### PR TITLE
fix upgrading pip to v10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,7 +108,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --upgrade pip"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,


### PR DESCRIPTION
Installing with `--user` option will leave the old pip.exe script in the $PATH, but then running the latter fails because pip 10 has moved its 'main' function to internal modules, and the old pip.exe launcher fails to import it.

The fix is to force overwriting the old pip.exe by installing globally without the `--user` option.

pypa/pip#5240 (comment)

Also see https://github.com/google/brotli/pull/663