### PR TITLE
appveyor.yml: Add py36 job

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,14 @@ environment:
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.5
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.5
+      PYTHON_ARCH: "64"
+
     # Python versions not pre-installed
 
     # Python 2.6.6 is the latest Python 2.6 with a Windows installer


### PR DESCRIPTION
This adds py36 job for the preinstalled release
that comes with appveyor.

Closes https://github.com/ogrisel/python-appveyor-demo/issues/44